### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/funkadelic/ha-acwd/security/code-scanning/1](https://github.com/funkadelic/ha-acwd/security/code-scanning/1)

To fix this issue, we should define a `permissions` block specifying the minimum required access for the workflow. Since the provided workflow only uses checkout and a validation action (hassfest) and does not appear to upload artifacts, modify workflows, or interact with pull requests/issues, it likely only needs read access to repository contents. Therefore, set `permissions: contents: read` at the workflow root—just beneath the `name` field and above the `on` field—so it applies to every job within this workflow. No changes to the jobs or steps are needed, nor are any imports or additional definitions required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->