### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/funkadelic/ha-acwd/security/code-scanning/3](https://github.com/funkadelic/ha-acwd/security/code-scanning/3)

To address this issue, explicitly add a `permissions` block that sets the minimal necessary privileges for the workflow. Since the current workflow just checks out code, runs tests, and uploads coverage, it is almost always sufficient to provide `contents: read`, which is the minimal permission needed to check out code. If any future steps require additional permissions, these can be granted specifically. 

The permissions block can be added either at the root of the workflow (applies to all jobs) or specifically under the job that runs the tests. Adding it at the root is preferred for clarity and maintainability; this ensures all jobs default to the least privilege. The block should be inserted after the `name:` and `on:` sections and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->