### PR TITLE
feat: Implement domain-scoped service registration with entry targeting

### DIFF
--- a/custom_components/acwd/__init__.py
+++ b/custom_components/acwd/__init__.py
@@ -268,7 +268,6 @@ async def _resolve_entry(hass: HomeAssistant, entry_id: str | None) -> ConfigEnt
     return entry
 
 
-# Configuration option keys
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ACWD Water Usage from a config entry."""
     hass.data.setdefault(DOMAIN, {})


### PR DESCRIPTION
### Changes:
- Add service unregistration in `async_unload_entry()` method
- Prevents memory leaks when integration is reloaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain-level import services added; hourly/daily imports can optionally target a specific configuration entry.

* **Bug Fixes**
  * Clearer errors/logging when a specified configuration is missing or unloaded.
  * Unloading a configuration no longer removes domain-level services.

* **Stability**
  * Improved initialization and per-entry handling for more reliable import operations and coordinator behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->