### PR TITLE
fix: Use Home Assistant timezone utilities for date calculations

### DIFF
--- a/custom_components/acwd/__init__.py
+++ b/custom_components/acwd/__init__.py
@@ -128,7 +128,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 return
 
             # Import into statistics
+            local_tz = dt_util.get_default_time_zone()
             date_dt = datetime.combine(date, datetime.min.time())
+            date_dt = date_dt.replace(tzinfo=local_tz)
+
             if granularity == "quarter_hourly":
                 await async_import_quarter_hourly_statistics(
                     hass, meter_number, hourly_records, date_dt
@@ -233,7 +236,7 @@ async def _async_import_initial_yesterday_data(
     It gives users immediate data to see in the Energy Dashboard.
     """
     try:
-        yesterday = (datetime.now() - timedelta(days=1)).date()
+        yesterday = (dt_util.now() - timedelta(days=1)).date()
         _LOGGER.info(f"Initial setup: Importing yesterday's data ({yesterday})")
 
         # Create a fresh client instance to avoid session conflicts


### PR DESCRIPTION
#### Changes 

* Replaced all datetime.now() with dt_util.now() for timezone awareness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone-aware handling for all time-based imports and scheduling so today/yesterday/hour and date-time calculations respect the system/local timezone.
  * Fixed timing and guard logic to ensure scheduled imports run reliably and avoid missing or duplicate day/hour data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->