### PR TITLE
fix: use meter_number in daily stats import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/custom_components/acwd/__init__.py
+++ b/custom_components/acwd/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
+
 import requests
 import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -15,13 +15,14 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
-from .const import DOMAIN, DATE_FORMAT_SLASH_MDY
+
 from .acwd_api import ACWDClient
+from .const import DATE_FORMAT_SLASH_MDY, DOMAIN
 from .helpers import local_midnight
 from .statistics import (
+    async_import_daily_statistics,
     async_import_hourly_statistics,
     async_import_quarter_hourly_statistics,
-    async_import_daily_statistics,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,9 +47,7 @@ MORNING_IMPORT_END_HOUR = 12  # Only import yesterday's data before noon
 SERVICE_IMPORT_HOURLY_SCHEMA = vol.Schema(
     {
         vol.Required("date"): cv.date,
-        vol.Optional("granularity", default="hourly"): vol.In(
-            ["hourly", "quarter_hourly"]
-        ),
+        vol.Optional("granularity", default="hourly"): vol.In(["hourly", "quarter_hourly"]),
         vol.Optional("entry_id"): str,
     }
 )
@@ -89,18 +88,14 @@ def _get_coordinator(domain_data: dict, entry_id: str | None):
     if entry_id is not None:
         if entry_id not in domain_data:
             available = ", ".join(domain_data.keys())
-            raise ServiceValidationError(
-                f"Unknown entry_id '{entry_id}'. Available entries: {available}"
-            )
+            raise ServiceValidationError(f"Unknown entry_id '{entry_id}'. Available entries: {available}")
         return domain_data[entry_id]
 
     if len(domain_data) == 1:
         return next(iter(domain_data.values()))
 
     available = ", ".join(domain_data.keys())
-    raise ServiceValidationError(
-        f"Multiple ACWD entries configured. Specify entry_id. Available: {available}"
-    )
+    raise ServiceValidationError(f"Multiple ACWD entries configured. Specify entry_id. Available: {available}")
 
 
 async def handle_import_hourly(call: ServiceCall) -> None:
@@ -114,8 +109,7 @@ async def handle_import_hourly(call: ServiceCall) -> None:
     if date >= today:
         _LOGGER.debug("Service call rejected: date %s is today or future", date)
         raise ServiceValidationError(
-            "Date cannot be in the future. ACWD data has a reporting delay — "
-            "use a date at least 1 day in the past."
+            "Date cannot be in the future. ACWD data has a reporting delay — use a date at least 1 day in the past."
         )
 
     # Look up coordinator from hass.data[DOMAIN]
@@ -167,20 +161,14 @@ async def handle_import_hourly(call: ServiceCall) -> None:
         # Import into statistics
         date_dt = local_midnight(date)  # timezone-aware to prevent UTC baseline bugs
         if granularity == "quarter_hourly":
-            await async_import_quarter_hourly_statistics(
-                hass, meter_number, hourly_records, date_dt
-            )
+            await async_import_quarter_hourly_statistics(hass, meter_number, hourly_records, date_dt)
         else:
-            await async_import_hourly_statistics(
-                hass, meter_number, hourly_records, date_dt
-            )
+            await async_import_hourly_statistics(hass, meter_number, hourly_records, date_dt)
 
         _LOGGER.info("Successfully imported %s data for %s", granularity, date)
 
     except (requests.Timeout, requests.ConnectionError) as err:
-        raise HomeAssistantError(
-            f"Network error communicating with ACWD portal: {err}"
-        ) from err
+        raise HomeAssistantError(f"Network error communicating with ACWD portal: {err}") from err
     except (ServiceValidationError, HomeAssistantError):
         raise
     except Exception as err:
@@ -222,9 +210,9 @@ async def handle_import_daily(call: ServiceCall) -> None:
         if not logged_in:
             raise HomeAssistantError(ERROR_LOGIN_FAILED)
 
-        account_number = service_client.user_info.get("AccountNumber")
-        if not account_number:
-            raise HomeAssistantError("Account number not available")
+        meter_number = service_client.meter_number
+        if not meter_number:
+            raise HomeAssistantError("Meter number not available")
 
         # Format dates for API
         start_str = start_date.strftime(DATE_FORMAT_SLASH_MDY)
@@ -248,16 +236,12 @@ async def handle_import_daily(call: ServiceCall) -> None:
             raise HomeAssistantError("No daily data available for date range")
 
         # Import into statistics
-        await async_import_daily_statistics(hass, str(account_number), daily_records)
+        await async_import_daily_statistics(hass, meter_number, daily_records)
 
-        _LOGGER.info(
-            "Successfully imported daily data from %s to %s", start_date, end_date
-        )
+        _LOGGER.info("Successfully imported daily data from %s to %s", start_date, end_date)
 
     except (requests.Timeout, requests.ConnectionError) as err:
-        raise HomeAssistantError(
-            f"Network error communicating with ACWD portal: {err}"
-        ) from err
+        raise HomeAssistantError(f"Network error communicating with ACWD portal: {err}") from err
     except (ServiceValidationError, HomeAssistantError):
         raise
     except Exception as err:
@@ -293,9 +277,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_import_initial_yesterday_data(
-    hass: HomeAssistant, coordinator: "ACWDDataUpdateCoordinator"
-) -> None:
+async def _async_import_initial_yesterday_data(hass: HomeAssistant, coordinator: ACWDDataUpdateCoordinator) -> None:
     """Import yesterday's data on first setup to provide immediate feedback to users.
 
     This is a one-time import that runs when the integration is first installed.
@@ -348,12 +330,8 @@ async def _async_import_initial_yesterday_data(
             return
 
         # Import into statistics
-        date_dt = local_midnight(
-            yesterday
-        )  # timezone-aware to prevent UTC baseline bugs
-        await async_import_hourly_statistics(
-            hass, meter_number, hourly_records, date_dt
-        )
+        date_dt = local_midnight(yesterday)  # timezone-aware to prevent UTC baseline bugs
+        await async_import_hourly_statistics(hass, meter_number, hourly_records, date_dt)
 
         _LOGGER.info(
             "Initial setup: Successfully imported %d hours for %s",
@@ -363,8 +341,7 @@ async def _async_import_initial_yesterday_data(
 
     except (requests.Timeout, requests.ConnectionError) as err:
         _LOGGER.warning(
-            "Initial import: Network error communicating with ACWD portal: %s "
-            "(will be retried on the next update cycle)",
+            "Initial import: Network error communicating with ACWD portal: %s (will be retried on the next update cycle)",
             err,
         )
     except Exception as err:
@@ -383,9 +360,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Check if this was the last loaded entry
         other_loaded_entries = [
-            _entry
-            for _entry in hass.config_entries.async_loaded_entries(DOMAIN)
-            if _entry.entry_id != entry.entry_id
+            _entry for _entry in hass.config_entries.async_loaded_entries(DOMAIN) if _entry.entry_id != entry.entry_id
         ]
         if not other_loaded_entries:
             hass.services.async_remove(DOMAIN, SERVICE_IMPORT_HOURLY)
@@ -397,9 +372,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching ACWD data."""
 
-    def __init__(
-        self, hass: HomeAssistant, client: ACWDClient, entry: ConfigEntry
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, client: ACWDClient, entry: ConfigEntry) -> None:
         """Initialize."""
         self.client = client
         self.entry = entry
@@ -426,9 +399,7 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
                 raise UpdateFailed(ERROR_LOGIN_FAILED)
 
             # Get billing cycle data (mode='B' for complete summary data)
-            data = await self.hass.async_add_executor_job(
-                self.client.get_usage_data, "B"
-            )
+            data = await self.hass.async_add_executor_job(self.client.get_usage_data, "B")
 
             if not data:
                 raise UpdateFailed("No data returned from ACWD portal")
@@ -521,16 +492,10 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("No non-zero usage found for %s", today)
 
             # Import into statistics (duplicates are automatically handled)
-            date_dt = local_midnight(
-                today
-            )  # timezone-aware to prevent UTC baseline bugs
-            await async_import_hourly_statistics(
-                self.hass, meter_number, hourly_records, date_dt
-            )
+            date_dt = local_midnight(today)  # timezone-aware to prevent UTC baseline bugs
+            await async_import_hourly_statistics(self.hass, meter_number, hourly_records, date_dt)
 
-            _LOGGER.info(
-                "Imported %s hourly records for %s", len(hourly_records), today
-            )
+            _LOGGER.info("Imported %s hourly records for %s", len(hourly_records), today)
 
         except Exception as err:
             _LOGGER.warning("Failed to auto-import hourly data for %s: %s", today, err)
@@ -552,9 +517,7 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
         yesterday = (dt_util.now() - timedelta(days=1)).date()
 
         try:
-            _LOGGER.debug(
-                "Early morning check: Importing complete data for %s", yesterday
-            )
+            _LOGGER.debug("Early morning check: Importing complete data for %s", yesterday)
 
             # Format date for API
             date_str = yesterday.strftime(DATE_FORMAT_SLASH_MDY)
@@ -587,12 +550,8 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
                 return
 
             # Import into statistics (duplicates are automatically handled)
-            date_dt = local_midnight(
-                yesterday
-            )  # timezone-aware to prevent UTC baseline bugs
-            await async_import_hourly_statistics(
-                self.hass, meter_number, hourly_records, date_dt
-            )
+            date_dt = local_midnight(yesterday)  # timezone-aware to prevent UTC baseline bugs
+            await async_import_hourly_statistics(self.hass, meter_number, hourly_records, date_dt)
 
             _LOGGER.info(
                 "Early morning import: Updated %s hourly records for %s",
@@ -601,6 +560,4 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
         except Exception as err:
-            _LOGGER.warning(
-                "Failed to import complete yesterday data for %s: %s", yesterday, err
-            )
+            _LOGGER.warning("Failed to import complete yesterday data for %s: %s", yesterday, err)

--- a/custom_components/acwd/__init__.py
+++ b/custom_components/acwd/__init__.py
@@ -210,15 +210,11 @@ async def handle_import_daily(call: ServiceCall) -> None:
         if not logged_in:
             raise HomeAssistantError(ERROR_LOGIN_FAILED)
 
-        meter_number = service_client.meter_number
-        if not meter_number:
-            raise HomeAssistantError("Meter number not available")
-
         # Format dates for API
         start_str = start_date.strftime(DATE_FORMAT_SLASH_MDY)
         end_str = end_date.strftime(DATE_FORMAT_SLASH_MDY)
 
-        # Fetch daily data
+        # Fetch daily data (also triggers meter discovery)
         data = await hass.async_add_executor_job(
             service_client.get_usage_data,
             "D",  # mode
@@ -228,6 +224,11 @@ async def handle_import_daily(call: ServiceCall) -> None:
 
         if not data:
             raise HomeAssistantError(f"No data returned for {start_date} to {end_date}")
+
+        # Get meter number from client (populated by get_usage_data -> _discover_meter)
+        meter_number = service_client.meter_number
+        if not meter_number:
+            raise HomeAssistantError("Meter number not available")
 
         # Extract daily records
         daily_records = data.get("objUsageGenerationResultSetTwo", [])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -508,6 +508,7 @@ class TestHandleImportDailyErrors:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
+            mock_client.get_usage_data.return_value = {"objUsageGenerationResultSetTwo": [{"Date": "12/01/2025"}]}
             mock_client.meter_number = None
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -482,7 +482,6 @@ class TestHandleImportDailyErrors:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.meter_number = "12345"
             mock_client.get_usage_data.return_value = None
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
@@ -761,7 +760,6 @@ class TestHandleImportDailyEdgeCases:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.meter_number = "12345"
             mock_client.get_usage_data.side_effect = RuntimeError("unexpected")
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -489,7 +489,8 @@ class TestHandleImportDailyErrors:
             with pytest.raises(HomeAssistantError, match="No data returned"):
                 await handle_import_daily(call)
 
-    async def test_no_meter_number_raises_error(self):
+    @pytest.mark.parametrize("meter_value", [None, ""])
+    async def test_no_meter_number_raises_error(self, meter_value):
         """Missing meter number raises HomeAssistantError."""
 
         hass = _make_mock_hass()
@@ -508,7 +509,7 @@ class TestHandleImportDailyErrors:
             mock_client = MagicMock()
             mock_client.login.return_value = True
             mock_client.get_usage_data.return_value = {"objUsageGenerationResultSetTwo": [{"Date": "12/01/2025"}]}
-            mock_client.meter_number = None
+            mock_client.meter_number = meter_value
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -255,10 +255,11 @@ class TestServiceValidation:
             patch(
                 "custom_components.acwd.async_import_daily_statistics",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_import_daily,
         ):
             mock_client = MagicMock()
             mock_client.login.return_value = True
+            mock_client.meter_number = "230057301"
             mock_client.get_usage_data.return_value = {
                 "objUsageGenerationResultSetTwo": [
                     {"Date": "12/01/2025", "UsageValue": 50.0},
@@ -271,6 +272,10 @@ class TestServiceValidation:
                 await handle_import_daily(call)
             except ServiceValidationError:
                 pytest.fail("ServiceValidationError raised for a valid date range")
+
+            # Verify meter_number (not account_number) is passed to import function
+            mock_import_daily.assert_called_once()
+            assert mock_import_daily.call_args[0][1] == "230057301"
 
 
 # ---------------------------------------------------------------------------
@@ -477,16 +482,16 @@ class TestHandleImportDailyErrors:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
+            mock_client.meter_number = "12345"
             mock_client.get_usage_data.return_value = None
-            mock_client.user_info = {"AccountNumber": "12345"}
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
 
             with pytest.raises(HomeAssistantError, match="No data returned"):
                 await handle_import_daily(call)
 
-    async def test_no_account_number_raises_error(self):
-        """Missing account number raises HomeAssistantError."""
+    async def test_no_meter_number_raises_error(self):
+        """Missing meter number raises HomeAssistantError."""
 
         hass = _make_mock_hass()
         entry = _make_mock_entry()
@@ -503,11 +508,11 @@ class TestHandleImportDailyErrors:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.user_info = {}
+            mock_client.meter_number = None
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
 
-            with pytest.raises(HomeAssistantError, match="Account number not available"):
+            with pytest.raises(HomeAssistantError, match="Meter number not available"):
                 await handle_import_daily(call)
 
     async def test_no_daily_records_raises_error(self):
@@ -528,7 +533,7 @@ class TestHandleImportDailyErrors:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.user_info = {"AccountNumber": "12345"}
+            mock_client.meter_number = "12345"
             mock_client.get_usage_data.return_value = {"objUsageGenerationResultSetTwo": []}
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
@@ -755,7 +760,7 @@ class TestHandleImportDailyEdgeCases:
         with patch("custom_components.acwd.ACWDClient") as mock_client_cls:
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.user_info = {"AccountNumber": "12345"}
+            mock_client.meter_number = "12345"
             mock_client.get_usage_data.side_effect = RuntimeError("unexpected")
             mock_client.logout.return_value = None
             mock_client_cls.return_value = mock_client
@@ -786,7 +791,7 @@ class TestHandleImportDailyEdgeCases:
         ):
             mock_client = MagicMock()
             mock_client.login.return_value = True
-            mock_client.user_info = {"AccountNumber": "12345"}
+            mock_client.meter_number = "230057301"
             mock_client.get_usage_data.return_value = {
                 "objUsageGenerationResultSetTwo": [
                     {"Date": "12/01/2025", "UsageValue": 50.0},


### PR DESCRIPTION
## Summary

- Fix `handle_import_daily` to use `meter_number` instead of `account_number` for statistic ID, consistent with `handle_import_hourly`
- Add `.pre-commit-config.yaml` with ruff and standard pre-commit hooks

The meter number fix addresses an inconsistency where daily stats used the account number while hourly stats used the meter number (since v1.0.7). For most users these are different values, meaning daily import statistics would be stored under a different ID than hourly ones.

**Note:** If you have previously used the `acwd.import_daily_data` service, your existing daily statistics (stored under the old account number-based ID) will remain in the database but won't be appended to. Re-importing the same date range will create new entries under the correct meter number-based ID. This does not affect hourly statistics or the Energy Dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated meter identification mechanism for improved reliability
  * Adjusted error messages for clarity on missing meter data

* **Tests**
  * Updated and expanded tests to validate meter-number handling and related error cases

* **Chores**
  * Added automated code quality checks via pre-commit hooks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->