### PR TITLE
docs: bump minimum Home Assistant version to 2025.4

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -18,7 +18,7 @@ Then restart Home Assistant and proceed to [Configuration](#configuration).
 
 ### Prerequisites
 
-- Home Assistant 2024.2.0 or newer
+- Home Assistant 2025.4.0 or newer
 - HACS installed
 
 ### Steps

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Home Assistant][ha-badge]][ha-link]
 
 # ha-acwd
+
 ACWD Water Usage Integration for Home Assistant
 
 **ha-acwd** is an open-source Python integration that imports water usage data from Alameda County Water District into Home Assistant for use in automation and monitoring.
@@ -40,7 +41,7 @@ After ACWD deployed [AMI (Advanced Metering Infrastructure) smart meters](https:
 ## Available Entities
 
 | Entity | Description | Unit |
-|--------|-------------|------|
+| ------ | ----------- | ---- |
 | Current Cycle Usage | Water used in current billing cycle | Gallons |
 | Current Cycle Projected | Projected total for current billing cycle | Gallons |
 | Last Billing Cycle | Previous billing cycle usage | Gallons |
@@ -102,8 +103,8 @@ This is an unofficial tool and is not affiliated with or endorsed by ACWD. Use a
 [build-badge]: https://github.com/funkadelic/ha-acwd/actions/workflows/tests.yml/badge.svg
 [coverage-badge]: https://img.shields.io/codecov/c/github/funkadelic/ha-acwd?logo=codecov
 [release-badge]: https://img.shields.io/github/v/release/funkadelic/ha-acwd
-[hacs-badge]: https://img.shields.io/badge/HACS-Custom-orange
-[ha-badge]: https://img.shields.io/badge/Home%20Assistant-2024.2+-blue
+[hacs-badge]: https://img.shields.io/badge/HACS-Default-orange
+[ha-badge]: https://img.shields.io/badge/Home%20Assistant-2025.4+-blue
 
 [build-link]: https://github.com/funkadelic/ha-acwd/actions/workflows/tests.yml
 [coverage-link]: https://codecov.io/gh/funkadelic/ha-acwd

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "ACWD Water Usage",
   "country": "US",
-  "homeassistant": "2024.2.0"
+  "homeassistant": "2025.4.0"
 }


### PR DESCRIPTION
## Summary

- Bump the declared minimum Home Assistant version from **2024.2** to **2025.4** across `hacs.json` (authoritative), `README.md` badge, and `INSTALLATION.md` prerequisites
- `custom_components/acwd/statistics.py` imports `StatisticMeanType` from `homeassistant.components.recorder.statistics` and uses `StatisticMeanType.NONE`. `StatisticMeanType` was **introduced in HA 2025.4** (verified against `home-assistant/core` tags 2025.3 vs 2025.4). On any HA older than 2025.4, the integration fails to load with `ImportError` at module import time, so the previously documented minimum was not accurate.
- Also refresh the HACS badge from `Custom` to `Default` and minor markdown tidy in `README.md` (blank line after heading, table separator spacing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Home Assistant minimum version requirement from 2024.2.0 to 2025.4.0 in installation guide and project badges.

* **Chores**
  * Updated project configuration to reflect new minimum Home Assistant version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->