### PR TITLE
fix: add zip_release to hacs.json for filename support

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
   "name": "ACWD Water Usage",
   "country": "US",
   "homeassistant": "2025.4.0",
-  "filename": "acwd.zip"
+  "filename": "acwd.zip",
+  "zip_release": true
 }


### PR DESCRIPTION
## Summary
- HACS requires `zip_release: true` when using the `filename` key; added it to `hacs.json` so release assets are recognized correctly.