### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Generate app token
         id: app-token

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,9 +16,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -41,6 +49,6 @@ jobs:
       - name: Upload release assets
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.release.outputs.tag_name }}
         run: gh release upload "$TAG" acwd.zip acwd.zip.sha256 --clobber


### PR DESCRIPTION
## Summary
- Use a GitHub App token instead of the default `GITHUB_TOKEN` for release-please, so PRs it opens trigger downstream workflows (tests, ruff, codecov) without manual close/reopen.
- Also uses the App token for uploading release assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation security by implementing GitHub App token authentication for improved access control during release and asset deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->