### PR TITLE
ci: skip codecov/sonarqube on release-please PRs and suppress PR header/footer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    drafts: false
+    base_branches:
+      - "!release-please--**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,13 +44,17 @@ jobs:
           pytest --cov-report=xml --junitxml=junit.xml
 
       - name: SonarQube Scan
-        if: env.SONAR_TOKEN != '' && matrix.python-version == '3.13'
+        if: >-
+          ${{ env.SONAR_TOKEN != '' && matrix.python-version == '3.13'
+          && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.13'
+        if: >-
+          ${{ matrix.python-version == '3.13'
+          && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
@@ -60,7 +64,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && matrix.python-version == '3.13' }}
+        if: >-
+          ${{ !cancelled() && matrix.python-version == '3.13'
+          && !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
         uses: codecov/codecov-action@v6
         with:
           files: ./junit.xml

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md",
-      "pull-request-footer": "",
+      "pull-request-header": " ",
+      "pull-request-footer": " ",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- Skip SonarQube and Codecov steps on release-please PRs (label `autorelease: pending`) since no code changes.
- Add `.coderabbit.yaml` to exclude release-please branches from CodeRabbit reviews.
- Set release-please `pull-request-header` and `pull-request-footer` to blank space to suppress defaults.