### PR TITLE
fix: prevent negative midnight water usage from import ordering

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,5 @@
 reviews:
   auto_review:
     drafts: false
-    base_branches:
-      - "!release-please--**"
+    ignore_title_keywords:
+      - "chore(main): release"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,28 @@ Thumbs.db
 .credentials
 *.credentials
 run_tests_local.bat
+
+# Env files (keep .env.example checked in)
+.env.*
+!.env.example
+
+# Editors / misc
+*~
+*.code-workspace
+
+# Test / build artifacts
+*.log
+.coverage
+coverage/
+htmlcov/
+.cache/
+.pytest_cache/
+.ruff_cache/
+tmp/
+
+.gsd
+.gsd-id
+.bg-shell/
+.planning/
+.claude/
+.mcp.json

--- a/custom_components/acwd/__init__.py
+++ b/custom_components/acwd/__init__.py
@@ -405,12 +405,10 @@ class ACWDDataUpdateCoordinator(DataUpdateCoordinator):
             if not data:
                 raise UpdateFailed("No data returned from ACWD portal")
 
-            # Automatically import today's hourly data
-            await self._import_today_hourly_data()
-
-            # Also import yesterday's data during early morning hours (0-12 PM)
-            # to catch the last few hours that become available overnight
+            # Yesterday catch-up MUST run before today's import — otherwise today's baseline
+            # anchors against an incomplete yesterday, producing negative midnight buckets.
             await self._import_yesterday_complete_data()
+            await self._import_today_hourly_data()
 
             return data
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1360,6 +1360,32 @@ class TestCoordinatorAsyncUpdateData:
         assert result == {"summary": "data"}
         coord.client.logout.assert_called_once()
 
+    async def test_yesterday_import_runs_before_today_import(self):
+        """Regression: yesterday catch-up must precede today's import so today's midnight baseline is correct."""
+        coord = self._make_coordinator()
+        coord.client.login.return_value = True
+        coord.client.get_usage_data.return_value = {"summary": "data"}
+        coord.client.logout.return_value = None
+
+        call_order = []
+
+        async def mock_yesterday():
+            call_order.append("yesterday")
+
+        async def mock_today():
+            call_order.append("today")
+
+        coord._import_yesterday_complete_data = mock_yesterday
+        coord._import_today_hourly_data = mock_today
+
+        await coord._async_update_data()
+
+        assert call_order == ["yesterday", "today"], (
+            "yesterday catch-up must run before today's partial import to ensure "
+            "today's baseline is anchored against the fully-updated yesterday final sum. "
+            f"Actual order: {call_order}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # ACWDDataUpdateCoordinator._import_today_hourly_data


### PR DESCRIPTION
## Summary
- Swap the two auto-import calls in `_async_update_data` so yesterday's catch-up runs before today's partial import. Prevents today's midnight baseline from anchoring against an incomplete yesterday total and producing a negative midnight bucket in the Energy Dashboard.
- Add a regression test enforcing the call order.
- Housekeeping: add local test/build/tooling artifacts to `.gitignore`.

## Root cause
- ACWD portal has a 3-4 h reporting delay — yesterday's 21:00–23:00 hours don't land until after midnight.
- In the 0–12 AM catch-up window, today's partial import was running first and anchoring today's midnight running total against whatever yesterday final total was in HA at that moment (still incomplete).
- The subsequent yesterday catch-up then imported the late-night hours, raising yesterday's final running total above today's already-committed midnight running total.
- Energy Dashboard computes \`today_midnight_usage = today_midnight_total − yesterday_final_total\` → negative, until a later coordinator cycle re-imported today against the now-correct baseline.

## Fix
Swap the order of the two awaits in \`ACWDDataUpdateCoordinator._async_update_data\` so yesterday catch-up runs first. The baseline logic in \`statistics.py\` is correct and unchanged.

## User-visible effect
The Energy Dashboard midnight-hour bucket no longer shows a transient negative value when checked in the early morning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data import sequencing to ensure correct baseline calculations for daily/hourly data processing.

* **Tests**
  * Added regression test validating proper data import execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->