### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -12,6 +13,7 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the release-please workflow so it can be run on demand from the Actions tab or via `gh workflow run release-please.yml`, instead of only on push to `main`.

The manual run still only opens/updates the release PR; merging that PR remains the publish step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to support manual triggering.
  * Limited release execution to pushes on the main branch to ensure releases run only in the intended context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->