### PR TITLE
ci: show build/ci/chore commits in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,9 +23,9 @@
         { "type": "refactor", "section": "Changed" },
         { "type": "docs",     "section": "Documentation" },
         { "type": "test",     "section": "Testing" },
-        { "type": "build",    "section": "Changed", "hidden": true },
-        { "type": "ci",       "section": "Changed", "hidden": true },
-        { "type": "chore",    "section": "Changed", "hidden": true }
+        { "type": "build",    "section": "Changed" },
+        { "type": "ci",       "section": "Changed" },
+        { "type": "chore",    "section": "Changed" }
       ]
     }
   }


### PR DESCRIPTION
Removes `hidden: true` from the `build`, `ci`, and `chore` entries in `changelog-sections` so those commits appear under the **Changed** section of release notes going forward.

Note: this only affects note *visibility*. It does not change which commit types *trigger* a release — release-please still bumps only on `feat`/`fix`/breaking. A chore/ci-only backlog will still report no user-facing changes and require a `Release-As` override to release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog configuration to include additional sections in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->